### PR TITLE
print more info when version resolution results in a conflict

### DIFF
--- a/aether-api/src/main/java/org/sonatype/aether/collection/UnsolvableVersionConflictException.java
+++ b/aether-api/src/main/java/org/sonatype/aether/collection/UnsolvableVersionConflictException.java
@@ -32,6 +32,14 @@ public class UnsolvableVersionConflictException
         this.versions = ( versions != null ) ? versions : Collections.<String> emptyList();
     }
 
+    public UnsolvableVersionConflictException( Object dependencyConflictId, Collection<String> versions, String customMessage )
+    {
+        super( "Could not resolve version conflict for " + dependencyConflictId + " with requested versions "
+            + toList( versions ) + ", details: " + customMessage);
+        this.dependencyConflictId = ( dependencyConflictId != null ) ? dependencyConflictId : "";
+        this.versions = ( versions != null ) ? versions : Collections.<String> emptyList();
+    }
+
     private static String toList( Collection<String> versions )
     {
         StringBuilder buffer = new StringBuilder( 256 );

--- a/aether-api/src/main/java/org/sonatype/aether/graph/Dependency.java
+++ b/aether-api/src/main/java/org/sonatype/aether/graph/Dependency.java
@@ -230,5 +230,4 @@ public final class Dependency
         hash = hash * 31 + exclusions.length;
         return hash;
     }
-
 }

--- a/aether-api/src/main/java/org/sonatype/aether/graph/DependencyNode.java
+++ b/aether-api/src/main/java/org/sonatype/aether/graph/DependencyNode.java
@@ -25,6 +25,12 @@ import org.sonatype.aether.version.VersionConstraint;
  */
 public interface DependencyNode
 {
+    /**
+     * Gets the parent node of this node.
+     * 
+     * @return The parent node of this node or {@code null} if root node.
+     */
+    DependencyNode getParent();
 
     /**
      * Gets the child nodes of this node.

--- a/aether-impl/src/main/java/org/sonatype/aether/impl/internal/DefaultDependencyCollector.java
+++ b/aether-impl/src/main/java/org/sonatype/aether/impl/internal/DefaultDependencyCollector.java
@@ -210,10 +210,13 @@ public class DefaultDependencyCollector
             edge.setRelocations( descriptorResult.getRelocations() );
             edge.setVersionConstraint( rangeResult.getVersionConstraint() );
             edge.setVersion( version );
+            node.setIngoingEdge(edge);
         }
         else
         {
-            edge = new GraphEdge( null, new GraphNode() );
+            GraphNode graphNode = new GraphNode();
+            edge = new GraphEdge( null, graphNode );
+            graphNode.setIngoingEdge(edge);
         }
 
         result.setRoot( edge );
@@ -507,6 +510,7 @@ public class DefaultDependencyCollector
                     edge.setRequestContext( result.getRequest().getRequestContext() );
 
                     node.getOutgoingEdges().add( edge );
+                    child.setIngoingEdge(edge);
 
                     if ( recurse )
                     {

--- a/aether-impl/src/main/java/org/sonatype/aether/impl/internal/GraphEdge.java
+++ b/aether-impl/src/main/java/org/sonatype/aether/impl/internal/GraphEdge.java
@@ -65,6 +65,15 @@ class GraphEdge
         return target;
     }
 
+    public DependencyNode getParent()
+    {
+        GraphNode s = getSource();
+        if (s != null)
+            return s.getIngoingEdge();
+        else
+            return null;
+    }
+
     public List<DependencyNode> getChildren()
     {
         return getTarget().getOutgoingEdges();

--- a/aether-impl/src/main/java/org/sonatype/aether/impl/internal/GraphNode.java
+++ b/aether-impl/src/main/java/org/sonatype/aether/impl/internal/GraphNode.java
@@ -23,12 +23,24 @@ import org.sonatype.aether.repository.RemoteRepository;
 class GraphNode
 {
 
+    private DependencyNode ingoingEdge;
+
     private List<DependencyNode> outgoingEdges = new ArrayList<DependencyNode>( 0 );
 
     private Collection<Artifact> aliases = Collections.emptyList();
 
     private List<RemoteRepository> repositories = Collections.emptyList();
 
+    public DependencyNode getIngoingEdge()
+    {
+        return ingoingEdge;
+    }
+
+    public void setIngoingEdge(DependencyNode ingoingEdge)
+    {
+        this.ingoingEdge = ingoingEdge;
+    }
+    
     public List<DependencyNode> getOutgoingEdges()
     {
         return outgoingEdges;

--- a/aether-test-util/src/main/java/org/sonatype/aether/test/util/impl/TestDependencyNode.java
+++ b/aether-test-util/src/main/java/org/sonatype/aether/test/util/impl/TestDependencyNode.java
@@ -32,6 +32,8 @@ public class TestDependencyNode
     implements DependencyNode
 {
 
+    private DependencyNode parent;
+
     private List<DependencyNode> children = new ArrayList<DependencyNode>( 0 );
 
     private Dependency dependency;
@@ -79,6 +81,7 @@ public class TestDependencyNode
      */
     public TestDependencyNode( DependencyNode node )
     {
+        setParent(node.getParent());
         setDependency( node.getDependency() );
         setAliases( node.getAliases() );
         setRequestContext( node.getRequestContext() );
@@ -88,6 +91,16 @@ public class TestDependencyNode
         setRepositories( node.getRepositories() );
         setVersion( node.getVersion() );
         setVersionConstraint( node.getVersionConstraint() );
+    }
+
+    public DependencyNode getParent()
+    {
+        return parent;
+    }
+
+    public void setParent(DependencyNode parent)
+    {
+        this.parent = parent;
     }
 
     public List<DependencyNode> getChildren()

--- a/aether-util/src/main/java/org/sonatype/aether/util/graph/DefaultDependencyNode.java
+++ b/aether-util/src/main/java/org/sonatype/aether/util/graph/DefaultDependencyNode.java
@@ -32,6 +32,8 @@ public class DefaultDependencyNode
     implements DependencyNode
 {
 
+    private DependencyNode parent;
+
     private List<DependencyNode> children = new ArrayList<DependencyNode>( 0 );
 
     private Dependency dependency;
@@ -79,6 +81,7 @@ public class DefaultDependencyNode
      */
     public DefaultDependencyNode( DependencyNode node )
     {
+        setParent(node.getParent());
         setDependency( node.getDependency() );
         setAliases( node.getAliases() );
         setRequestContext( node.getRequestContext() );
@@ -89,6 +92,16 @@ public class DefaultDependencyNode
         setVersion( node.getVersion() );
         setVersionConstraint( node.getVersionConstraint() );
         setData( node.getData() );
+    }
+
+    public DependencyNode getParent()
+    {
+        return parent;
+    }
+
+    public void setParent(DependencyNode parent)
+    {
+        this.parent = parent;
     }
 
     public List<DependencyNode> getChildren()

--- a/aether-util/src/main/java/org/sonatype/aether/util/graph/transformer/NearestVersionConflictResolver.java
+++ b/aether-util/src/main/java/org/sonatype/aether/util/graph/transformer/NearestVersionConflictResolver.java
@@ -8,7 +8,9 @@ package org.sonatype.aether.util.graph.transformer;
  * http://www.eclipse.org/legal/epl-v10.html
  *******************************************************************************/
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
@@ -17,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.sonatype.aether.RepositoryException;
+import org.sonatype.aether.artifact.Artifact;
 import org.sonatype.aether.collection.DependencyGraphTransformationContext;
 import org.sonatype.aether.collection.DependencyGraphTransformer;
 import org.sonatype.aether.collection.UnsolvableVersionConflictException;
@@ -187,7 +190,58 @@ public class NearestVersionConflictResolver
         {
             versions.add( constraint.toString() );
         }
-        return new UnsolvableVersionConflictException( group.key, versions );
+        if (group.positions == null || group.positions.isEmpty())
+        {
+            return new UnsolvableVersionConflictException(group.key, versions);
+        }
+        StringBuilder sb = new StringBuilder();
+        boolean first = true;
+        for ( Position position : group.positions )
+        {
+            if (position == null)
+                continue;
+            List<String> depList = new ArrayList<String>();
+            DependencyNode node = position.parent;
+            while (node != null)
+            {
+                if(node.getDependency() == null)
+                    break;
+                Artifact artifact = node.getDependency().getArtifact();
+                if (artifact == null)
+                    break;
+                String groupId = emptyIfNull (artifact.getGroupId());
+                String artifactId = emptyIfNull (artifact.getArtifactId());
+                String version = emptyIfNull (artifact.getVersion());
+                String artifactString = groupId + "." + artifactId + ":" + version;
+                depList.add(artifactString);
+                node = node.getParent();
+            }
+            Collections.reverse (depList);
+            if (depList.size() > 0)
+            {
+                StringBuilder depString = new StringBuilder ();
+                depString.append(depList.remove(0));
+                for (String artifactString : depList)
+                    depString.append ("-->").append (artifactString);
+                if (first)
+                {
+                    sb.append(depString.toString());
+                    first = false;
+                } else
+                {
+                    sb.append(" ; ").append(depString.toString());
+                }
+            }
+        }
+        return new UnsolvableVersionConflictException( group.key, versions, sb.toString() );
+    }
+
+    private String emptyIfNull (String s)
+    {
+        if (s == null)
+            return "";
+        else
+            return s;
     }
 
     private boolean isNearer( Position pos1, Version ver1, Position pos2, Version ver2 )


### PR DESCRIPTION
Hello,

The provided change is adding more information to the UnsolvableVersionConflictException, when a version conflict arises. However the necessary information was not being gathered, so I needed to add ingoingEdges to DependencyNodes (slight changes in interfaces and implementor classes) and properly gather the information in DefaultDependencyCollector.
To test the new behaviour you can change the NearestVersionConflictResolverTest.testUnsolvableRangeConflictBetweenHardConstraints()
to catch the thrown exception and watch its .detailMessage. It will include dependency subtrees of conflicting artifacts/versions.

Please let me know if you don't like something about the change, I will be happy to adjust it.

Cheers,
Peter
