### PR TITLE
Added PostorderNodeListGenerator

### DIFF
--- a/aether-util/src/main/java/org/sonatype/aether/util/graph/AbstractDepthFirstDependencyTreeTraverser.java
+++ b/aether-util/src/main/java/org/sonatype/aether/util/graph/AbstractDepthFirstDependencyTreeTraverser.java
@@ -32,8 +32,8 @@ import java.util.Map;
  * implementations for {@link #visitEnter(org.sonatype.aether.graph.DependencyNode)} and
  * {@link #visitLeave(org.sonatype.aether.graph.DependencyNode)}
  *
- * @author Ansgar Konermann
  * @author Benjamin Bentmann
+ * @author Ansgar Konermann
  */
 public abstract class AbstractDepthFirstDependencyTreeTraverser
     implements DependencyVisitor

--- a/aether-util/src/main/java/org/sonatype/aether/util/graph/AbstractDepthFirstDependencyTreeTraverser.java
+++ b/aether-util/src/main/java/org/sonatype/aether/util/graph/AbstractDepthFirstDependencyTreeTraverser.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Copyright (c) 2010-2011 Sonatype, Inc.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * and Apache License v2.0 which accompanies this distribution.
+ * The Eclipse Public License is available at
+ *   http://www.eclipse.org/legal/epl-v10.html
+ * The Apache License v2.0 is available at
+ *   http://www.apache.org/licenses/LICENSE-2.0.html
+ * You may elect to redistribute this code under either of these licenses.
+ ******************************************************************************/
+
+package org.sonatype.aether.util.graph;
+
+import org.sonatype.aether.artifact.Artifact;
+import org.sonatype.aether.graph.Dependency;
+import org.sonatype.aether.graph.DependencyNode;
+import org.sonatype.aether.graph.DependencyVisitor;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Abstract base class for depth first dependency tree traversers. Subclasses of this visitor will visit each
+ * node exactly once regardless how many paths within the dependency graph lead to the node such that the
+ * resulting node sequence is free of duplicates.<br/>
+ * Actual vertex ordering (preorder, inorder, postorder) needs to be defined by subclasses through appropriate
+ * implementations for {@link #visitEnter(org.sonatype.aether.graph.DependencyNode)} and
+ * {@link #visitLeave(org.sonatype.aether.graph.DependencyNode)}
+ *
+ * @author Ansgar Konermann
+ * @author Benjamin Bentmann
+ */
+public abstract class AbstractDepthFirstDependencyTreeTraverser
+    implements DependencyVisitor
+{
+
+    protected final Map<DependencyNode, Object> visitedNodes;
+
+    protected final List<DependencyNode> nodes;
+
+    public AbstractDepthFirstDependencyTreeTraverser()
+    {
+        nodes = new ArrayList<DependencyNode>( 128 );
+        visitedNodes = new IdentityHashMap<DependencyNode, Object>( 512 );
+    }
+
+    /**
+     * Gets the list of dependency nodes that was generated during the graph traversal.
+     *
+     * @return The list of dependency nodes in preorder, never {@code null}.
+     */
+    public List<DependencyNode> getNodes()
+    {
+        return nodes;
+    }
+
+    /**
+     * Gets the dependencies seen during the graph traversal.
+     *
+     * @param includeUnresolved Whether unresolved dependencies shall be included in the result or not.
+     * @return The list of dependencies in preorder, never {@code null}.
+     */
+    public List<Dependency> getDependencies( boolean includeUnresolved )
+    {
+        List<Dependency> dependencies = new ArrayList<Dependency>( getNodes().size() );
+
+        for ( DependencyNode node : getNodes() )
+        {
+            Dependency dependency = node.getDependency();
+            if ( dependency != null )
+            {
+                if ( includeUnresolved || dependency.getArtifact().getFile() != null )
+                {
+                    dependencies.add( dependency );
+                }
+            }
+        }
+
+        return dependencies;
+    }
+
+    /**
+     * Gets the artifacts associated with the list of dependency nodes generated during the graph traversal.
+     *
+     * @param includeUnresolved Whether unresolved artifacts shall be included in the result or not.
+     * @return The list of artifacts in preorder, never {@code null}.
+     */
+    public List<Artifact> getArtifacts( boolean includeUnresolved )
+    {
+        List<Artifact> artifacts = new ArrayList<Artifact>( getNodes().size() );
+
+        for ( DependencyNode node : getNodes() )
+        {
+            if ( node.getDependency() != null )
+            {
+                Artifact artifact = node.getDependency().getArtifact();
+                if ( includeUnresolved || artifact.getFile() != null )
+                {
+                    artifacts.add( artifact );
+                }
+            }
+        }
+
+        return artifacts;
+    }
+
+    /**
+     * Gets the files of resolved artifacts seen during the graph traversal.
+     *
+     * @return The list of artifact files in preorder, never {@code null}.
+     */
+    public List<File> getFiles()
+    {
+        List<File> files = new ArrayList<File>( getNodes().size() );
+
+        for ( DependencyNode node : getNodes() )
+        {
+            if ( node.getDependency() != null )
+            {
+                File file = node.getDependency().getArtifact().getFile();
+                if ( file != null )
+                {
+                    files.add( file );
+                }
+            }
+        }
+
+        return files;
+    }
+
+    /**
+     * Gets a class path by concatenating the artifact files of the visited dependency nodes. Nodes with unresolved
+     * artifacts are automatically skipped.
+     *
+     * @return The class path, using the platform-specific path separator, never {@code null}.
+     */
+    public String getClassPath()
+    {
+        StringBuilder buffer = new StringBuilder( 1024 );
+
+        for ( Iterator<DependencyNode> it = getNodes().iterator(); it.hasNext(); )
+        {
+            DependencyNode node = it.next();
+            if ( node.getDependency() != null )
+            {
+                Artifact artifact = node.getDependency().getArtifact();
+                if ( artifact.getFile() != null )
+                {
+                    buffer.append( artifact.getFile().getAbsolutePath() );
+                    if ( it.hasNext() )
+                    {
+                        buffer.append( File.pathSeparatorChar );
+                    }
+                }
+            }
+        }
+
+        return buffer.toString();
+    }
+
+    protected void setAlreadyVisited( DependencyNode node )
+    {
+        visitedNodes.put( node, Boolean.TRUE );
+    }
+
+    protected boolean isAlreadyVisited( DependencyNode node )
+    {
+        return visitedNodes.containsKey( node );
+    }
+
+    public abstract boolean visitEnter( DependencyNode node );
+
+    public abstract boolean visitLeave( DependencyNode node );
+}

--- a/aether-util/src/main/java/org/sonatype/aether/util/graph/AbstractDepthFirstNodeListGenerator.java
+++ b/aether-util/src/main/java/org/sonatype/aether/util/graph/AbstractDepthFirstNodeListGenerator.java
@@ -35,7 +35,7 @@ import java.util.Map;
  * @author Benjamin Bentmann
  * @author Ansgar Konermann
  */
-public abstract class AbstractDepthFirstDependencyTreeTraverser
+public abstract class AbstractDepthFirstNodeListGenerator
     implements DependencyVisitor
 {
 
@@ -43,7 +43,7 @@ public abstract class AbstractDepthFirstDependencyTreeTraverser
 
     protected final List<DependencyNode> nodes;
 
-    public AbstractDepthFirstDependencyTreeTraverser()
+    public AbstractDepthFirstNodeListGenerator()
     {
         nodes = new ArrayList<DependencyNode>( 128 );
         visitedNodes = new IdentityHashMap<DependencyNode, Object>( 512 );
@@ -52,7 +52,7 @@ public abstract class AbstractDepthFirstDependencyTreeTraverser
     /**
      * Gets the list of dependency nodes that was generated during the graph traversal.
      *
-     * @return The list of dependency nodes in preorder, never {@code null}.
+     * @return The list of dependency nodes in the order defined by concrete subclasses, never {@code null}.
      */
     public List<DependencyNode> getNodes()
     {
@@ -63,7 +63,7 @@ public abstract class AbstractDepthFirstDependencyTreeTraverser
      * Gets the dependencies seen during the graph traversal.
      *
      * @param includeUnresolved Whether unresolved dependencies shall be included in the result or not.
-     * @return The list of dependencies in preorder, never {@code null}.
+     * @return The list of dependencies in the order defined by concrete subclasses, never {@code null}.
      */
     public List<Dependency> getDependencies( boolean includeUnresolved )
     {
@@ -88,7 +88,7 @@ public abstract class AbstractDepthFirstDependencyTreeTraverser
      * Gets the artifacts associated with the list of dependency nodes generated during the graph traversal.
      *
      * @param includeUnresolved Whether unresolved artifacts shall be included in the result or not.
-     * @return The list of artifacts in preorder, never {@code null}.
+     * @return The list of artifacts in the order defined by concrete subclasses, never {@code null}.
      */
     public List<Artifact> getArtifacts( boolean includeUnresolved )
     {
@@ -112,7 +112,7 @@ public abstract class AbstractDepthFirstDependencyTreeTraverser
     /**
      * Gets the files of resolved artifacts seen during the graph traversal.
      *
-     * @return The list of artifact files in preorder, never {@code null}.
+     * @return The list of artifact files in the order defined by concrete subclasses, never {@code null}.
      */
     public List<File> getFiles()
     {
@@ -163,14 +163,17 @@ public abstract class AbstractDepthFirstDependencyTreeTraverser
         return buffer.toString();
     }
 
-    protected void setAlreadyVisited( DependencyNode node )
+    protected VisitStatus ensureVisitedFlagIsSet( DependencyNode node )
     {
-        visitedNodes.put( node, Boolean.TRUE );
+        return visitedNodes.put( node, Boolean.TRUE ) == null
+            ? VisitStatus.FIRST_VISIT
+            : VisitStatus.WAS_VISITED_BEFORE;
     }
 
-    protected boolean isAlreadyVisited( DependencyNode node )
+    protected static enum VisitStatus
     {
-        return visitedNodes.containsKey( node );
+        FIRST_VISIT,
+        WAS_VISITED_BEFORE
     }
 
     public abstract boolean visitEnter( DependencyNode node );

--- a/aether-util/src/main/java/org/sonatype/aether/util/graph/PostorderNodeListGenerator.java
+++ b/aether-util/src/main/java/org/sonatype/aether/util/graph/PostorderNodeListGenerator.java
@@ -15,8 +15,7 @@ package org.sonatype.aether.util.graph;
 import org.sonatype.aether.graph.DependencyNode;
 
 /**
- * Generates a sequence of dependency nodes from a dependeny graph by traversing the graph in <em>preorder</em>
- * sequence.
+ * Generates a sequence of dependency nodes from a dependeny graph by traversing the graph in preorder.
  *
  * @author Ansgar Konermann
  */
@@ -42,13 +41,16 @@ public class PostorderNodeListGenerator
         {
             return true;
         }
+        else
+        {
+            setAlreadyVisited( node );
+        }
 
         if ( node.getDependency() != null )
         {
             nodes.add( node );
         }
 
-        setAlreadyVisited( node );
         return true;
     }
 

--- a/aether-util/src/main/java/org/sonatype/aether/util/graph/PostorderNodeListGenerator.java
+++ b/aether-util/src/main/java/org/sonatype/aether/util/graph/PostorderNodeListGenerator.java
@@ -15,19 +15,32 @@ package org.sonatype.aether.util.graph;
 import org.sonatype.aether.graph.DependencyNode;
 
 /**
- * Generates a sequence of dependency nodes from a dependeny graph by traversing the graph in preorder.
+ * Generates a sequence of dependency nodes from a dependeny graph by traversing the graph in <em>preorder</em>
+ * sequence.
  *
- * @author Benjamin Bentmann
+ * @author Ansgar Konermann
  */
-public class PreorderNodeListGenerator
+public class PostorderNodeListGenerator
     extends AbstractDepthFirstDependencyTreeTraverser
 {
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean visitEnter( DependencyNode node )
     {
+        return true;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean visitLeave( DependencyNode node )
+    {
         if ( isAlreadyVisited( node ) )
         {
-            return false;
+            return true;
         }
 
         if ( node.getDependency() != null )
@@ -36,12 +49,6 @@ public class PreorderNodeListGenerator
         }
 
         setAlreadyVisited( node );
-        return true;
-    }
-
-    @Override
-    public boolean visitLeave( DependencyNode node )
-    {
         return true;
     }
 

--- a/aether-util/src/main/java/org/sonatype/aether/util/graph/PostorderNodeListGenerator.java
+++ b/aether-util/src/main/java/org/sonatype/aether/util/graph/PostorderNodeListGenerator.java
@@ -20,7 +20,7 @@ import org.sonatype.aether.graph.DependencyNode;
  * @author Ansgar Konermann
  */
 public class PostorderNodeListGenerator
-    extends AbstractDepthFirstDependencyTreeTraverser
+    extends AbstractDepthFirstNodeListGenerator
 {
     /**
      * {@inheritDoc}
@@ -37,13 +37,9 @@ public class PostorderNodeListGenerator
     @Override
     public boolean visitLeave( DependencyNode node )
     {
-        if ( isAlreadyVisited( node ) )
+        if ( ensureVisitedFlagIsSet( node ) == VisitStatus.WAS_VISITED_BEFORE )
         {
             return true;
-        }
-        else
-        {
-            setAlreadyVisited( node );
         }
 
         if ( node.getDependency() != null )

--- a/aether-util/src/main/java/org/sonatype/aether/util/graph/PreorderNodeListGenerator.java
+++ b/aether-util/src/main/java/org/sonatype/aether/util/graph/PreorderNodeListGenerator.java
@@ -20,18 +20,14 @@ import org.sonatype.aether.graph.DependencyNode;
  * @author Benjamin Bentmann
  */
 public class PreorderNodeListGenerator
-    extends AbstractDepthFirstDependencyTreeTraverser
+    extends AbstractDepthFirstNodeListGenerator
 {
     @Override
     public boolean visitEnter( DependencyNode node )
     {
-        if ( isAlreadyVisited( node ) )
+        if ( ensureVisitedFlagIsSet( node ) == VisitStatus.WAS_VISITED_BEFORE )
         {
             return false;
-        }
-        else
-        {
-            setAlreadyVisited( node );
         }
 
         if ( node.getDependency() != null )

--- a/aether-util/src/main/java/org/sonatype/aether/util/graph/PreorderNodeListGenerator.java
+++ b/aether-util/src/main/java/org/sonatype/aether/util/graph/PreorderNodeListGenerator.java
@@ -29,13 +29,16 @@ public class PreorderNodeListGenerator
         {
             return false;
         }
+        else
+        {
+            setAlreadyVisited( node );
+        }
 
         if ( node.getDependency() != null )
         {
             nodes.add( node );
         }
 
-        setAlreadyVisited( node );
         return true;
     }
 


### PR DESCRIPTION
Hi,

the PostoderNodeListGenerator is useful when you have to deal with trees of dependencys where all the children have to be available (loaded into memory) before the parent (root) node can be processed/loaded.

Example: JBoss Drools (rule engine). When dealing with rule/knowledge "packages", all child packages have to be available in the engine's internal knowledge repository before any package depending on them can be loaded. In contrast to java, there is no such thing as "lazy on-demand linking"; all references get resolved eagerly.

As I'm working my way through to a maven module which is capable of compiling drools rules into knowledge packages in a truly modular fashion ("JAR" like), I need this vertex order during tree traversal. I thought it might be useful for other Aether users too.
